### PR TITLE
feat/horizon-backend - Connecting to Horizon.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,12 +9,17 @@
 </template>
 
 <script>
+  import Horizon from '@horizon/client';
+  import Vue from 'vue';
+
   import TopMenu from './components/TopMenu.vue';
   import PageFooter from './components/PageFooter.vue';
 
   export default {
     data () {
       return {
+        horizon: Horizon({host: 'localhost:8181'}),
+        eventBus: new Vue(),
         msg: 'Wazzup | Horizon | RethinkDB'
       }
     },

--- a/src/components/InvoceList.vue
+++ b/src/components/InvoceList.vue
@@ -5,7 +5,7 @@
       Invoices
     </h1>
 
-    <div class="ui basic segment">
+    <div class="ui basic segment" :class="{ 'loading' : isLoading }">
       <table class="ui single line stripped table">
         <thead>
         <tr>
@@ -56,10 +56,40 @@
 </style>
 <script>
   export default{
+    name: 'InvoiceList',
     data(){
       return {
-        msg: 'hello vue'
+        invoicesService: this.$root.horizon('invoices'),
+        isLoading: false,
+        invoices: []
       }
+    },
+    methods: {
+      listenMessages() {
+        this.invoicesService.limit(10).watch()
+          .subscribe(invoices => {
+            this.invoices = [...invoices];
+          },
+          error => console.log(error)
+        );
+      }
+    },
+    created() {
+      this.isLoading = true;
+
+      this.$root.horizon.onReady()
+        .subscribe(() => {
+          console.log("Connected to Horizon server");
+
+          this.isLoading = false;
+          this.listenMessages();
+        }
+      );
+
+
+      this.$root.horizon.onDisconnected()
+         .subscribe(() => console.log("Disconnected from Horizon server")
+      );
     },
     components: {}
   }

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,5 @@
 import Vue from 'vue'
 import VueRouter from 'vue-router';
-import Horizon from '@horizon/client';
 
 import App from './App.vue';
 import Home from './components/Home.vue';
@@ -35,10 +34,6 @@ const router = new VueRouter({
 
 new Vue(Vue.util.extend({
   router,
-  data: {
-    horizon: Horizon({host: 'localhost:8181'}),
-    eventBus: new Vue()
-  }
 }, App)).$mount('#app');
 
 router.beforeEach(function (transition, redirect, next) {


### PR DESCRIPTION
## App.vue
- Adding Horizon client so it's available application-wide.
- Adding event Bus to App, also available app-wide.
## InvoceList.vue
- Binding Horizon methods.
### Note:

Remember to run with `hz serve --dev --start-rethinkdb no` if you already have RethinkDB running.
